### PR TITLE
refactor(http): remove default Content-Type header from HTTP requests

### DIFF
--- a/src/main/resources/archetype-resources/__rootArtifactId__-common/src/main/java/util/HttpUtils.java
+++ b/src/main/resources/archetype-resources/__rootArtifactId__-common/src/main/java/util/HttpUtils.java
@@ -32,7 +32,6 @@ public class HttpUtils {
 
     private static final int CALL_TIMEOUT_M = 3;
     private static final String DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36";
-    private static final String DEFAULT_CONTENT_TYPE = "application/json";
     private static final String DEFAULT_ACCEPT = "*/*";
     private static final HttpClient client = HttpClient.newBuilder()
             .version(HttpClient.Version.HTTP_1_1)
@@ -49,7 +48,6 @@ public class HttpUtils {
         HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .header("User-Agent", DEFAULT_USER_AGENT)
-                .header("Content-Type", DEFAULT_CONTENT_TYPE)
                 .header("Accept", DEFAULT_ACCEPT);
         if (MapUtils.isNotEmpty(headers)) {
             headers.forEach(builder::header);
@@ -166,7 +164,6 @@ public class HttpUtils {
     public static String toCurl(String url, Map<String, String> headers, String body, String method) {
         Map<String, String> httpHeaders = new HashMap<>();
         httpHeaders.put("User-Agent", DEFAULT_USER_AGENT);
-        httpHeaders.put("Content-Type", DEFAULT_CONTENT_TYPE);
         httpHeaders.put("Accept", DEFAULT_ACCEPT);
         if (MapUtils.isNotEmpty(headers)) {
             httpHeaders.putAll(headers);


### PR DESCRIPTION
- Deleted the DEFAULT_CONTENT_TYPE constant from HttpUtils
- Removed Content-Type header from HTTP request builder
- Excluded Content-Type header from default headers in toCurl method
- Simplified header management by not setting Content-Type implicitly